### PR TITLE
Fix + enhance publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - v*
+      - 'v*!rc*'
 
 jobs:
   build-n-publish:

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - v*rc*
+      - 'v*rc*'
 
 jobs:
   build-n-publish:

--- a/.github/workflows/test-pypi-publish.yml
+++ b/.github/workflows/test-pypi-publish.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - v*
+      - v*rc*
 
 jobs:
   build-n-publish:
@@ -35,4 +35,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,13 +3,13 @@
 # Copyright (C) 2023-2024 Northwestern University.
 #
 
-name: invenio-subjects-mesh-lite CI
-
 on:
   push:
-    branches: master
+    branches:
+      - master
   pull_request:
-    branches: master
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       reason:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ name = "invenio-subjects-mesh-lite"
 readme = "README.md"
 requires-python = ">=3.8"
 urls = {Repository = "https://github.com/galterlibrary/invenio-subjects-mesh-lite"}
-version = "2024.2.26"
+version = "2024.2.26rc1"
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ name = "invenio-subjects-mesh-lite"
 readme = "README.md"
 requires-python = ">=3.8"
 urls = {Repository = "https://github.com/galterlibrary/invenio-subjects-mesh-lite"}
-version = "2024.2.26rc1"
+version = "2024.2.26"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
- Basically makes sure that the release build uses a supported version of Python (3.10) for the project.
- Adds some niceties to test deployment on Test PyPI. Any tags of the `"v*rc*"` format will trigger a release on Test PyPI instead of PyPI. We don't use rc releases on PyPI, so that's legitimate.