### PR TITLE
:package: release: v2025.1.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,10 @@ version = "2025.1.15.2"
 [project.optional-dependencies]
 dev = [
     "check-manifest>=0.49",
-    "invenio-search[opensearch2]>=2.1.0,<3.0",  # Needs to be specified separately as it's normally up to the instance
+    "invenio-search[opensearch2]>=3.0.0,<4.0.0",  # Needs to be specified separately as it's normally up to the instance
     "invoke>=2.2,<3.0",
     "pyyaml>=5.4.1",
-    "pytest-invenio>=2.1.1,<3.0.0",
+    "pytest-invenio>=2.1.1,<4.0.0",
 ]
 
 dev_pre = [


### PR DESCRIPTION
Will merge this right away. It's only to provide the correct commit message for the version. The previous commit message was incorrect. 

The updates to the deps is just because v13 is actually out.