### PR TITLE
chore: remove python version metadata per Python support policy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,6 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "invenio-subjects-mesh-common>=0.2.0,<2.0"


### PR DESCRIPTION
Immediate purpose: this removes 3.x classifiers per our Python version policy https://github.com/galter-dmt/developer-resources/pull/1 .

Secondary purpose: this PR and the other invenio-subjects-mesh ones + galter-subjects-utils one, were a test run for using https://github.com/lindell/multi-gitter for multi-repo wide changes+PRs. Works well enough!